### PR TITLE
Improve write performance for operations on tables with indexes + Bugfix for `remove`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10242,7 +10242,7 @@
       "license": "MIT",
       "dependencies": {
         "@ngneat/falso": "^6.1.0",
-        "blinkdb": "^0.0.0",
+        "blinkdb": "^0.6.0",
         "clone": "^2.1.2",
         "lokijs": "^1.5.12"
       },
@@ -10255,7 +10255,7 @@
     },
     "packages/db": {
       "name": "blinkdb",
-      "version": "1.0.0",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -10862,7 +10862,7 @@
         "@ngneat/falso": "^6.1.0",
         "@types/clone": "^2.1.1",
         "@types/lokijs": "^1.5.7",
-        "blinkdb": "^1.0.0",
+        "blinkdb": "^0.6.0",
         "clone": "^2.1.2",
         "lokijs": "^1.5.12",
         "sorted-btree": "^1.8.0",

--- a/packages/benchmarks/src/benchmarks/blinkdb.ts
+++ b/packages/benchmarks/src/benchmarks/blinkdb.ts
@@ -10,9 +10,7 @@ interface User {
 
 (async () => {
   // BlinkDB setup
-  const blinkdb = createDB({
-    clone: true,
-  });
+  const blinkdb = createDB();
   const blinkUserTable = createTable<User>(blinkdb, "users")();
   const blinkUserTableWithIndex = createTable<User>(
     blinkdb,

--- a/packages/benchmarks/src/benchmarks/blinkdb.ts
+++ b/packages/benchmarks/src/benchmarks/blinkdb.ts
@@ -1,0 +1,87 @@
+import { randFirstName } from "@ngneat/falso";
+import { clear, createDB, createTable, first, insert, remove, update } from "blinkdb";
+import { compare } from "../framework";
+
+interface User {
+  id: number;
+  name: string;
+  age?: number;
+}
+
+(async () => {
+  // BlinkDB setup
+  const blinkdb = createDB({
+    clone: true,
+  });
+  const blinkUserTable = createTable<User>(blinkdb, "users")();
+  const blinkUserTableWithIndex = createTable<User>(
+    blinkdb,
+    "usersWithIndex"
+  )({ primary: "id", indexes: ["name"] });
+
+  // Prefill users
+  let users: User[] = [];
+  for (let i = 0; i < 10000; i++) {
+    users.push({
+      id: i,
+      name: randFirstName(),
+      age: Math.random() > 0.2 ? Math.random() * 40 : undefined,
+    });
+  }
+
+  await compare(
+    "creating 10.000 items",
+    {
+      "blinkdb with index": async () => {
+        for (let user of users) {
+          await insert(blinkUserTableWithIndex, user);
+        }
+      },
+      "blinkdb with no index": async () => {
+        for (let user of users) {
+          await insert(blinkUserTable, user);
+        }
+      },
+    },
+    {
+      runs: 100,
+      beforeEach: () => {
+        clear(blinkUserTable);
+        clear(blinkUserTableWithIndex);
+      },
+    }
+  );
+
+  await compare("updating one item", {
+    "blinkdb with index": async () => {
+      const x = await update(blinkUserTableWithIndex, {
+        id: 2,
+        age: 13,
+        name: randFirstName(),
+      });
+    },
+    "blinkdb with no index": async () => {
+      const x = await update(blinkUserTable, { id: 2, age: 13, name: randFirstName() });
+    },
+  });
+
+  await compare(
+    "removing one item",
+    {
+      "blinkdb with index": async () => {
+        const x = await remove(blinkUserTableWithIndex, { id: 2 });
+      },
+      "blinkdb with no index": async () => {
+        const x = await remove(blinkUserTable, { id: 2 });
+      },
+    },
+    {
+      beforeEach: async () => {
+        if ((await first(blinkUserTable, { where: { id: 2 } })) == null) {
+          await insert(blinkUserTableWithIndex, users[2]);
+          await insert(blinkUserTable, users[2]);
+        }
+      },
+    }
+  );
+})();

--- a/packages/benchmarks/src/benchmarks/index.ts
+++ b/packages/benchmarks/src/benchmarks/index.ts
@@ -1,2 +1,3 @@
 //import "./map-vs-btree.ts";
 import "./blinkdb-vs-lokijs.ts";
+//import "./blinkdb.ts";

--- a/packages/db/src/core/createDB.ts
+++ b/packages/db/src/core/createDB.ts
@@ -23,7 +23,7 @@ export function createDB(options?: Partial<DBOptions>): Database {
 
 export interface DBOptions {
   /**
-   * Toggles whether entities are cloned before being written with function `insert` or
+   * Toggles whether entities are cloned before being written with `insert` or
    * returned from functions like `many()`, `first()` or `one()`.
    *
    * If enabled, adds a performance cost, but prevents the user from modifying

--- a/packages/db/src/core/createDB.ts
+++ b/packages/db/src/core/createDB.ts
@@ -23,7 +23,8 @@ export function createDB(options?: Partial<DBOptions>): Database {
 
 export interface DBOptions {
   /**
-   * Toggles whether entities are cloned before being returned from functions like `many()`, `first()` or `one()`.
+   * Toggles whether entities are cloned before being written with function `insert` or
+   * returned from functions like `many()`, `first()` or `one()`.
    *
    * If enabled, adds a performance cost, but prevents the user from modifying
    * the returned entities directly, which would bring the database into an inconsistent state.

--- a/packages/db/src/core/insert.ts
+++ b/packages/db/src/core/insert.ts
@@ -38,7 +38,7 @@ export async function insert<T, P extends keyof T>(
     if (key === null || key === undefined) continue;
 
     const items = btree.get(key);
-    if (items != null) {
+    if (items !== undefined) {
       items.push(storageEntity);
     } else {
       btree.set(key, [storageEntity]);

--- a/packages/db/src/core/insert.ts
+++ b/packages/db/src/core/insert.ts
@@ -37,9 +37,9 @@ export async function insert<T, P extends keyof T>(
     const key = (entity as any)[property];
     if (key === null || key === undefined) continue;
 
-    if (btree.has(key)) {
-      const items = btree.get(key)!;
-      btree.set(key, [...items, storageEntity]);
+    const items = btree.get(key);
+    if (items != null) {
+      items.push(storageEntity);
     } else {
       btree.set(key, [storageEntity]);
     }

--- a/packages/db/src/core/remove.spec.ts
+++ b/packages/db/src/core/remove.spec.ts
@@ -12,12 +12,18 @@ interface User {
 
 let db: Database;
 let userTable: Table<User, "id">;
+let userTableWithIndex: Table<User, "id">;
 
 beforeEach(async () => {
   db = createDB();
   userTable = createTable<User>(db, "users")();
+  userTableWithIndex = createTable<User>(
+    db,
+    "users"
+  )({ primary: "id", indexes: ["name"] });
 
   await insert(userTable, { id: 0, name: "Alice", age: 16 });
+  await insert(userTableWithIndex, { id: 0, name: "Alice", age: 16 });
   await insert(userTable, { id: 1, name: "Bob" });
   await insert(userTable, { id: 2, name: "Charlie", age: 49 });
 });
@@ -36,4 +42,12 @@ it("should remove an entity", async () => {
   await remove(userTable, { id: 1 });
   const bob = await first(userTable, { where: { id: 1 } });
   expect(bob).toBe(null);
+});
+
+it("should correctly remove an entity from a table with index", async () => {
+  await remove(userTableWithIndex, { id: 0 });
+  const alice = await first(userTableWithIndex, { where: { id: 0 } });
+  expect(alice).toBe(null);
+  const alice2 = await first(userTableWithIndex, { where: { name: "Alice" } });
+  expect(alice2).toBe(null);
 });

--- a/packages/db/src/core/remove.spec.ts
+++ b/packages/db/src/core/remove.spec.ts
@@ -12,18 +12,12 @@ interface User {
 
 let db: Database;
 let userTable: Table<User, "id">;
-let userTableWithIndex: Table<User, "id">;
 
 beforeEach(async () => {
   db = createDB();
   userTable = createTable<User>(db, "users")();
-  userTableWithIndex = createTable<User>(
-    db,
-    "users"
-  )({ primary: "id", indexes: ["name"] });
 
   await insert(userTable, { id: 0, name: "Alice", age: 16 });
-  await insert(userTableWithIndex, { id: 0, name: "Alice", age: 16 });
   await insert(userTable, { id: 1, name: "Bob" });
   await insert(userTable, { id: 2, name: "Charlie", age: 49 });
 });
@@ -45,9 +39,13 @@ it("should remove an entity", async () => {
 });
 
 it("should correctly remove an entity from a table with index", async () => {
-  await remove(userTableWithIndex, { id: 0 });
-  const alice = await first(userTableWithIndex, { where: { id: 0 } });
+  userTable = createTable<User>(db, "users")({ primary: "id", indexes: ["name"] });
+
+  await insert(userTable, { id: 0, name: "Alice", age: 16 });
+
+  await remove(userTable, { id: 0 });
+  const alice = await first(userTable, { where: { id: 0 } });
   expect(alice).toBe(null);
-  const alice2 = await first(userTableWithIndex, { where: { name: "Alice" } });
+  const alice2 = await first(userTable, { where: { name: "Alice" } });
   expect(alice2).toBe(null);
 });

--- a/packages/db/src/core/remove.ts
+++ b/packages/db/src/core/remove.ts
@@ -28,7 +28,7 @@ export async function remove<T, P extends keyof T>(
   const item =
     indexEntries.length > 0 ? table[BlinkKey].storage.primary.get(primaryKey) : null;
   const deleted = table[BlinkKey].storage.primary.delete(primaryKey);
-  if (item != null) {
+  if (item !== undefined) {
     for (const [property, btree] of indexEntries) {
       const key = (item as any)[property];
       if (key == null) continue;

--- a/packages/db/src/core/remove.ts
+++ b/packages/db/src/core/remove.ts
@@ -20,20 +20,29 @@ export async function remove<T, P extends keyof T>(
 ): Promise<boolean> {
   const primaryKeyProperty = table[BlinkKey].options.primary;
   const primaryKey = entity[primaryKeyProperty];
-  const deleted = table[BlinkKey].storage.primary.delete(primaryKey);
-  for (const [property, btree] of Object.entries<BTree<any, T[]>>(
+  const indexEntries = Object.entries<BTree<any, T[]>>(
     table[BlinkKey].storage.indexes as any
-  )) {
-    const key = (entity as any)[property];
-    if (key === null || key === undefined) continue;
+  );
+  // For tables without indexes, it is not necessary to retrieve the actual entity before deleting it
+  // For tables with indexes, we need the full entity to find all corresponding index entries
+  const item =
+    indexEntries.length > 0 ? table[BlinkKey].storage.primary.get(primaryKey) : null;
+  const deleted = table[BlinkKey].storage.primary.delete(primaryKey);
+  if (item != null) {
+    for (const [property, btree] of indexEntries) {
+      const key = (item as any)[property];
+      if (key == null) continue;
 
-    if (btree.has(key)) {
-      let items = btree.get(key)!;
-      items = items.filter((i) => i[primaryKeyProperty] !== primaryKey);
-      if (items.length === 0) {
-        btree.delete(key);
-      } else {
-        btree.set(key, items);
+      const items = btree.get(key);
+      if (items != null) {
+        const deleteIndex = items.indexOf(item);
+        if (deleteIndex !== -1) {
+          if (items.length === 1) {
+            btree.delete(key);
+          } else {
+            items.splice(deleteIndex, 1);
+          }
+        }
       }
     }
   }

--- a/packages/db/src/core/update.ts
+++ b/packages/db/src/core/update.ts
@@ -36,15 +36,18 @@ export async function update<T, P extends keyof T>(
       const btree = table[BlinkKey].storage.indexes[key as keyof T];
       if (btree !== undefined) {
         let oldIndexItems = btree.get(oldItem[key as keyof T])!;
-        oldIndexItems = oldIndexItems?.filter(
-          (i) => i[primaryKeyProperty] !== oldItem[primaryKeyProperty]
-        );
-        btree.set(oldItem[key as keyof T], oldIndexItems);
+        const arrayIndex = oldIndexItems.indexOf(item);
+        if (arrayIndex !== -1) {
+          // This only happens if clone is disabled and the user changed the indexed property without calling update
+          oldIndexItems.splice(arrayIndex, 1);
+        }
+
         const newIndexItems = btree.get(diff[key as keyof Diff<T, P>] as T[keyof T]);
-        btree.set(
-          diff[key as keyof Diff<T, P>] as T[keyof T],
-          newIndexItems ? [...newIndexItems, item] : [item]
-        );
+        if (newIndexItems != null) {
+          newIndexItems.push(item);
+        } else {
+          btree.set(diff[key as keyof Diff<T, P>] as T[keyof T], [item]);
+        }
       }
     }
   }

--- a/packages/db/src/core/update.ts
+++ b/packages/db/src/core/update.ts
@@ -37,8 +37,8 @@ export async function update<T, P extends keyof T>(
       if (btree !== undefined) {
         let oldIndexItems = btree.get(oldItem[key as keyof T])!;
         const arrayIndex = oldIndexItems.indexOf(item);
+        // This condition is only false if clone is disabled and the user changed the indexed property without calling update
         if (arrayIndex !== -1) {
-          // This only happens if clone is disabled and the user changed the indexed property without calling update
           oldIndexItems.splice(arrayIndex, 1);
         }
 

--- a/packages/db/src/core/update.ts
+++ b/packages/db/src/core/update.ts
@@ -43,7 +43,7 @@ export async function update<T, P extends keyof T>(
         }
 
         const newIndexItems = btree.get(diff[key as keyof Diff<T, P>] as T[keyof T]);
-        if (newIndexItems != null) {
+        if (newIndexItems !== undefined) {
           newIndexItems.push(item);
         } else {
           btree.set(diff[key as keyof Diff<T, P>] as T[keyof T], [item]);


### PR DESCRIPTION
I have changed some create/remove operations to now edit the array in-memory instead of allocating a new array which should be a lot faster:

![grafik](https://user-images.githubusercontent.com/13384066/189772334-1941d4a3-a68c-4476-a1e9-663ca3be69ed.png)

This should not change the behavior in any observable way (unless an index array contains the same item multiple times, which should not happen as far as I know) but provides a significant performance boost especially when inserting entries.

I added some benchmarks below, using a table with 1 index. However, the performance increase is even bigger when using multiple indexes (e.g. creating 10.000 items with 5 indexes takes 40ms now instead of 78ms, using clone in both cases).

Additionally, I fixed a small bug in the remove implementation that I stumbled upon.

## Create 10.000 items:
### Before
```
  blinkdb with index      took 24.31350ms, high 95.36340ms, low 22.92340ms
  blinkdb with no index   took 12.05970ms, high 106.57190ms, low 9.89640ms
```
### After
```
  blinkdb with index      took 18.07080ms, high 74.83170ms, low 15.48300ms
  blinkdb with no index   took 11.05330ms, high 98.95320ms, low 10.08770ms
```

## Update one item:
### Before
```
  blinkdb with index      took 0.00510ms, high 1.11310ms, low 0.00200ms
  blinkdb with no index   took 0.00250ms, high 0.37020ms, low 0.00200ms
```

### After
```
  blinkdb with index      took 0.00300ms, high 0.67560ms, low 0.00200ms
  blinkdb with no index   took 0.00220ms, high 0.99160ms, low 0.00190ms
```

## Remove one item:
### Before
No before available due to a bug in the current implementation which leads to faster execution time (but a wrong result)

### After
```
  blinkdb with index      took 0.00580ms, high 2.15120ms, low 0.00270ms
  blinkdb with no index   took 0.00290ms, high 1.33420ms, low 0.00230ms
```