### PR TITLE
Limit performance increase + Bugfix for `many`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10242,7 +10242,7 @@
       "license": "MIT",
       "dependencies": {
         "@ngneat/falso": "^6.1.0",
-        "blinkdb": "^0.0.0",
+        "blinkdb": "^0.6.0",
         "clone": "^2.1.2",
         "lokijs": "^1.5.12"
       },
@@ -10255,7 +10255,7 @@
     },
     "packages/db": {
       "name": "blinkdb",
-      "version": "1.0.0",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -10862,7 +10862,7 @@
         "@ngneat/falso": "^6.1.0",
         "@types/clone": "^2.1.1",
         "@types/lokijs": "^1.5.7",
-        "blinkdb": "^1.0.0",
+        "blinkdb": "^0.6.0",
         "clone": "^2.1.2",
         "lokijs": "^1.5.12",
         "sorted-btree": "^1.8.0",

--- a/packages/benchmarks/src/benchmarks/blinkdb.ts
+++ b/packages/benchmarks/src/benchmarks/blinkdb.ts
@@ -1,0 +1,87 @@
+import { randFirstName } from "@ngneat/falso";
+import { clear, createDB, createTable, first, insert, remove, update } from "blinkdb";
+import { compare } from "../framework";
+
+interface User {
+  id: number;
+  name: string;
+  age?: number;
+}
+
+(async () => {
+  // BlinkDB setup
+  const blinkdb = createDB({
+    clone: true,
+  });
+  const blinkUserTable = createTable<User>(blinkdb, "users")();
+  const blinkUserTableWithIndex = createTable<User>(
+    blinkdb,
+    "usersWithIndex"
+  )({ primary: "id", indexes: ["name"] });
+
+  // Prefill users
+  let users: User[] = [];
+  for (let i = 0; i < 10000; i++) {
+    users.push({
+      id: i,
+      name: randFirstName(),
+      age: Math.random() > 0.2 ? Math.random() * 40 : undefined,
+    });
+  }
+
+  await compare(
+    "creating 10.000 items",
+    {
+      "blinkdb with index": async () => {
+        for (let user of users) {
+          await insert(blinkUserTableWithIndex, user);
+        }
+      },
+      "blinkdb with no index": async () => {
+        for (let user of users) {
+          await insert(blinkUserTable, user);
+        }
+      },
+    },
+    {
+      runs: 100,
+      beforeEach: () => {
+        clear(blinkUserTable);
+        clear(blinkUserTableWithIndex);
+      },
+    }
+  );
+
+  await compare("updating one item", {
+    "blinkdb with index": async () => {
+      const x = await update(blinkUserTableWithIndex, {
+        id: 2,
+        age: 13,
+        name: randFirstName(),
+      });
+    },
+    "blinkdb with no index": async () => {
+      const x = await update(blinkUserTable, { id: 2, age: 13, name: randFirstName() });
+    },
+  });
+
+  await compare(
+    "removing one item",
+    {
+      "blinkdb with index": async () => {
+        const x = await remove(blinkUserTableWithIndex, { id: 2 });
+      },
+      "blinkdb with no index": async () => {
+        const x = await remove(blinkUserTable, { id: 2 });
+      },
+    },
+    {
+      beforeEach: async () => {
+        if ((await first(blinkUserTable, { where: { id: 2 } })) == null) {
+          await insert(blinkUserTableWithIndex, users[2]);
+          await insert(blinkUserTable, users[2]);
+        }
+      },
+    }
+  );
+})();

--- a/packages/benchmarks/src/benchmarks/blinkdb.ts
+++ b/packages/benchmarks/src/benchmarks/blinkdb.ts
@@ -1,5 +1,14 @@
 import { randFirstName } from "@ngneat/falso";
-import { clear, createDB, createTable, first, insert, remove, update } from "blinkdb";
+import {
+  clear,
+  createDB,
+  createTable,
+  first,
+  insert,
+  many,
+  remove,
+  update,
+} from "blinkdb";
 import { compare } from "../framework";
 
 interface User {
@@ -84,4 +93,15 @@ interface User {
       },
     }
   );
+
+  await compare("many query with limit", {
+    blinkdb: async () => {
+      const x = await many(blinkUserTable, {
+        limit: {
+          skip: 5000,
+          take: 50,
+        },
+      });
+    },
+  });
 })();

--- a/packages/benchmarks/src/benchmarks/index.ts
+++ b/packages/benchmarks/src/benchmarks/index.ts
@@ -1,2 +1,3 @@
 //import "./map-vs-btree.ts";
 import "./blinkdb-vs-lokijs.ts";
+//import "./blinkdb.ts";

--- a/packages/db/src/core/createDB.ts
+++ b/packages/db/src/core/createDB.ts
@@ -23,7 +23,8 @@ export function createDB(options?: Partial<DBOptions>): Database {
 
 export interface DBOptions {
   /**
-   * Toggles whether entities are cloned before being returned from functions like `many()`, `first()` or `one()`.
+   * Toggles whether entities are cloned before being written with function `insert` or
+   * returned from functions like `many()`, `first()` or `one()`.
    *
    * If enabled, adds a performance cost, but prevents the user from modifying
    * the returned entities directly, which would bring the database into an inconsistent state.

--- a/packages/db/src/core/insert.ts
+++ b/packages/db/src/core/insert.ts
@@ -37,9 +37,9 @@ export async function insert<T, P extends keyof T>(
     const key = (entity as any)[property];
     if (key === null || key === undefined) continue;
 
-    if (btree.has(key)) {
-      const items = btree.get(key)!;
-      btree.set(key, [...items, storageEntity]);
+    const items = btree.get(key);
+    if (items != null) {
+      items.push(storageEntity);
     } else {
       btree.set(key, [storageEntity]);
     }

--- a/packages/db/src/core/many.spec.ts
+++ b/packages/db/src/core/many.spec.ts
@@ -752,5 +752,15 @@ describe("filter", () => {
 
       expect(items).toStrictEqual([bob, charlie]);
     });
+
+    it("should return items with only take specified", async () => {
+      const items = await many(userTable, {
+        limit: {
+          take: 2,
+        },
+      });
+
+      expect(items).toHaveLength(2);
+    });
   });
 });

--- a/packages/db/src/core/many.ts
+++ b/packages/db/src/core/many.ts
@@ -57,6 +57,8 @@ export async function many<T, P extends keyof T>(
 
     // Filter items
     items = filterItems(table, items, filter.where);
+  } else {
+    items = table[BlinkKey].storage.primary.valuesArray();
   }
 
   if (filter.sort) {

--- a/packages/db/src/core/remove.spec.ts
+++ b/packages/db/src/core/remove.spec.ts
@@ -12,12 +12,18 @@ interface User {
 
 let db: Database;
 let userTable: Table<User, "id">;
+let userTableWithIndex: Table<User, "id">;
 
 beforeEach(async () => {
   db = createDB();
   userTable = createTable<User>(db, "users")();
+  userTableWithIndex = createTable<User>(
+    db,
+    "users"
+  )({ primary: "id", indexes: ["name"] });
 
   await insert(userTable, { id: 0, name: "Alice", age: 16 });
+  await insert(userTableWithIndex, { id: 0, name: "Alice", age: 16 });
   await insert(userTable, { id: 1, name: "Bob" });
   await insert(userTable, { id: 2, name: "Charlie", age: 49 });
 });
@@ -36,4 +42,12 @@ it("should remove an entity", async () => {
   await remove(userTable, { id: 1 });
   const bob = await first(userTable, { where: { id: 1 } });
   expect(bob).toBe(null);
+});
+
+it("should correctly remove an entity from a table with index", async () => {
+  await remove(userTableWithIndex, { id: 0 });
+  const alice = await first(userTableWithIndex, { where: { id: 0 } });
+  expect(alice).toBe(null);
+  const alice2 = await first(userTableWithIndex, { where: { name: "Alice" } });
+  expect(alice2).toBe(null);
 });

--- a/packages/db/src/core/remove.ts
+++ b/packages/db/src/core/remove.ts
@@ -20,20 +20,29 @@ export async function remove<T, P extends keyof T>(
 ): Promise<boolean> {
   const primaryKeyProperty = table[BlinkKey].options.primary;
   const primaryKey = entity[primaryKeyProperty];
-  const deleted = table[BlinkKey].storage.primary.delete(primaryKey);
-  for (const [property, btree] of Object.entries<BTree<any, T[]>>(
+  const indexEntries = Object.entries<BTree<any, T[]>>(
     table[BlinkKey].storage.indexes as any
-  )) {
-    const key = (entity as any)[property];
-    if (key === null || key === undefined) continue;
+  );
+  // For tables without indexes, it is not necessary to retrieve the actual entity before deleting it
+  // For tables with indexes, we need the full entity to find all corresponding index entries
+  const item =
+    indexEntries.length > 0 ? table[BlinkKey].storage.primary.get(primaryKey) : null;
+  const deleted = table[BlinkKey].storage.primary.delete(primaryKey);
+  if (item != null) {
+    for (const [property, btree] of indexEntries) {
+      const key = (item as any)[property];
+      if (key == null) continue;
 
-    if (btree.has(key)) {
-      let items = btree.get(key)!;
-      items = items.filter((i) => i[primaryKeyProperty] !== primaryKey);
-      if (items.length === 0) {
-        btree.delete(key);
-      } else {
-        btree.set(key, items);
+      const items = btree.get(key);
+      if (items != null) {
+        const deleteIndex = items.indexOf(item);
+        if (deleteIndex !== -1) {
+          if (items.length === 1) {
+            btree.delete(key);
+          } else {
+            items.splice(deleteIndex, 1);
+          }
+        }
       }
     }
   }

--- a/packages/db/src/core/update.ts
+++ b/packages/db/src/core/update.ts
@@ -36,15 +36,18 @@ export async function update<T, P extends keyof T>(
       const btree = table[BlinkKey].storage.indexes[key as keyof T];
       if (btree !== undefined) {
         let oldIndexItems = btree.get(oldItem[key as keyof T])!;
-        oldIndexItems = oldIndexItems?.filter(
-          (i) => i[primaryKeyProperty] !== oldItem[primaryKeyProperty]
-        );
-        btree.set(oldItem[key as keyof T], oldIndexItems);
+        const arrayIndex = oldIndexItems.indexOf(item);
+        if (arrayIndex !== -1) {
+          // This only happens if clone is disabled and the user changed the indexed property without calling update
+          oldIndexItems.splice(arrayIndex, 1);
+        }
+
         const newIndexItems = btree.get(diff[key as keyof Diff<T, P>] as T[keyof T]);
-        btree.set(
-          diff[key as keyof Diff<T, P>] as T[keyof T],
-          newIndexItems ? [...newIndexItems, item] : [item]
-        );
+        if (newIndexItems != null) {
+          newIndexItems.push(item);
+        } else {
+          btree.set(diff[key as keyof Diff<T, P>] as T[keyof T], [item]);
+        }
       }
     }
   }

--- a/packages/db/src/core/update.ts
+++ b/packages/db/src/core/update.ts
@@ -37,8 +37,8 @@ export async function update<T, P extends keyof T>(
       if (btree !== undefined) {
         let oldIndexItems = btree.get(oldItem[key as keyof T])!;
         const arrayIndex = oldIndexItems.indexOf(item);
+        // This condition is only false if clone is disabled and the user changed the indexed property without calling update
         if (arrayIndex !== -1) {
-          // This only happens if clone is disabled and the user changed the indexed property without calling update
           oldIndexItems.splice(arrayIndex, 1);
         }
 

--- a/packages/db/src/query/limit/index.ts
+++ b/packages/db/src/query/limit/index.ts
@@ -15,29 +15,30 @@ export function limitItems<T, P extends keyof T>(
   }
 
   const primaryKeyProperty = table[BlinkKey].options.primary;
+  let fromIndex = 0;
+  let toIndex = items.length;
 
   if (limit.from !== undefined) {
-    while (
-      defaultComparator(
-        items[0][primaryKeyProperty] as unknown as string | number,
-        limit.from as unknown as string | number
-      ) < 0
-    ) {
-      items.shift();
-    }
+    fromIndex = items.findIndex(
+      (item) =>
+        defaultComparator(
+          item[primaryKeyProperty] as unknown as string | number,
+          limit.from as unknown as string | number
+        ) >= 0
+    );
   }
 
   if (limit.skip !== undefined) {
-    for (let i = 0; i < limit.skip; i++) {
-      items.shift();
-    }
+    fromIndex += limit.skip;
   }
 
   if (limit.take !== undefined) {
-    while (items.length > limit.take) {
-      items.pop();
-    }
+    toIndex = Math.min(fromIndex + limit.take, toIndex);
   }
 
-  return items;
+  if (fromIndex === 0 && toIndex === items.length) {
+    return items;
+  }
+
+  return items.slice(fromIndex, toIndex);
 }


### PR DESCRIPTION
depends on #3 for additional benchmarking (therefore this PR contains the other changes as well until it's merged).

I have changed `limitItems` to need way less array operations when limiting/paginating a large item data set.

I also fixed a bug with `many` which didn't return any items if filter options are defined but don't contain a `where` (e.g. when paginating the whole data set).

## many query with limit:
### Before
```
  blinkdb   took 0.41430ms, high 16.08050ms, low 0.40960ms
```
### After
```
  blinkdb   took 0.19070ms, high 2.21160ms, low 0.17670ms
```