### PR TITLE
Insert many performance optimizations

### DIFF
--- a/packages/db/src/core/insertMany.ts
+++ b/packages/db/src/core/insertMany.ts
@@ -1,6 +1,6 @@
+import { TableUtils } from "../core/table.utils";
 import { middleware } from "../events/Middleware";
 import { Entity, isOrdinal, PrimaryKeyOf } from "../types";
-import { clone } from "./clone";
 import { BlinkKey } from "./createDB";
 import { Table } from "./createTable";
 import { PrimaryKeyAlreadyInUseError } from "./errors";
@@ -40,7 +40,6 @@ export async function internalInsertMany<T extends Entity<T>, P extends PrimaryK
 
   const blinkTable = table[BlinkKey];
   const primaryKeyProperty = blinkTable.options.primary;
-  const shouldClone = blinkTable.db[BlinkKey].options.clone;
 
   const blinkTableStorage = blinkTable.storage;
   const primaryBtree = blinkTableStorage.primary;
@@ -52,7 +51,7 @@ export async function internalInsertMany<T extends Entity<T>, P extends PrimaryK
   for (const entity of entities) {
     const primaryKey = entity[primaryKeyProperty];
 
-    const storageEntity = shouldClone ? clone(entity) : entity;
+    const storageEntity = TableUtils.cloneIfNecessary(table, entity);
 
     const inserted = primaryBtree.set(primaryKey, storageEntity, false);
     if (!inserted) {

--- a/packages/db/src/events/Dispatcher.ts
+++ b/packages/db/src/events/Dispatcher.ts
@@ -23,6 +23,14 @@ export class Dispatcher<T = void> {
   public async dispatch(data: T): Promise<void> {
     this.callbacks.forEach((cb) => cb(data));
   }
+
+  /**
+   * Returns true if this dispatcher has listeners.
+   * If this returns false, then you can skip calling `dispatch` for performance optimizations.
+   */
+  public hasListeners(): boolean {
+    return this.callbacks.size > 0;
+  }
 }
 
 type Callback<T> = (data: T) => Promise<void> | void;


### PR DESCRIPTION
Some `insertMany` micro optimizations, leading to ~50% more Operations/s in my local `insert-many` benchmarks (but feel free to run the benchmarks on your PC as well):

Changes, sorted by performance impact (DESC):

* Only create `events` array if there are actually event listeners for the `onInsert` event.
* No longer use `primaryKey.has` to throw `PrimaryKeyAlreadyInUseError`, instead just try setting the btree value, using `overwrite = false`. If the key already exists, this function returns `false` and the error can be thrown there. This takes away one tree traversal for `has`, leading to better performance (unless the user sets `clone = true` and regularly inserts entries which throw a `PrimaryKeyAlreadyInUseError`, because the element is now cloned first, and then the insert afterwards checks if the element exists. But I think it's reasonable to optimize the non-error-case, especially since Error throwing is usually slow anyways).
* Entity-independent calls to `table[BlinkKey].storage.primary` etc. are now only done once in the beginning instead of once for each entity. This should slightly increase performance as well.

Possible further improvements, which are breaking changes:
* Change `onInsert` event from `{ entity: T }[]` to `T[]` so that it's not necessary to allocate new objects for the `events` list
* Don't return primary keys (or provide an optimized `insertMany` function which doesn't return them)