### PR TITLE
fix: hooks cause infinite rerender

### DIFF
--- a/packages/react/src/retrieval/useMany.ts
+++ b/packages/react/src/retrieval/useMany.ts
@@ -58,7 +58,7 @@ export function useMany<T extends Entity<T>, P extends PrimaryKeyOf<T>>(
       dispose = await run();
     });
     return dispose;
-  }, [table, query]);
+  }, [table, JSON.stringify(query)]);
 
   return {
     data: state,


### PR DESCRIPTION
the react blinkdb hooks causes there callers to rerender infinitely because the `useEffect` in `useMany` watches the `query` argument, which is a new object instance every time the caller rerenders.

A simple solution is to stringify the query in `useEffect`.